### PR TITLE
Add tool-schemas/ — JSON input_schema for 35 builtin tools (refs #22)

### DIFF
--- a/tool-schemas/README.md
+++ b/tool-schemas/README.md
@@ -5,11 +5,19 @@ the API request body Claude Code sends to Anthropic.
 
 Seeded from issue
 [#22](https://github.com/Piebald-AI/claude-code-system-prompts/issues/22).
-Covers the 29 tools shipped to the main agent loop in a standard Claude
-Code session. Tools that only appear under specific feature flags (Agent
-Teams / Cowork, computer-use, claude.ai/design, PowerShell on Windows,
-etc.) are out of scope for this initial PR — they need a capture from
-that context.
+
+- **29 default tools** shipped to the main agent loop in a standard
+  Claude Code session (`bash.json`, `read.json`, `edit.json`, …).
+- **3 Agent Teams tools** (`send-message.json`, `team-create.json`,
+  `team-delete.json`) captured under
+  `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` / `--agent-teams`. These
+  appear in the `tools[]` payload only when that gate is enabled
+  (`utils/agentSwarmsEnabled.ts`).
+
+Other build-time-gated tools (`SendUserFile`, `Snip`, `WebBrowser`, …
+behind `feature('KAIROS')` etc.) are not in the public npm bundle and so
+cannot be captured from a standard install; PowerShell needs a Windows
+host. Those remain out of scope for this PR.
 
 ## File contents
 

--- a/tool-schemas/README.md
+++ b/tool-schemas/README.md
@@ -4,95 +4,40 @@ JSON `input_schema` for Claude Code's builtin tools, captured verbatim from
 the API request body Claude Code sends to Anthropic.
 
 Seeded from issue
-[#22](https://github.com/Piebald-AI/system-prompts/issues/22). All 29 tools
-shipped in Claude Code v2.1.168 are covered.
+[#22](https://github.com/Piebald-AI/claude-code-system-prompts/issues/22).
+Covers the 29 tools shipped to the main agent loop.
 
-## What's in each file
+## File contents
 
 Each `<tool>.json` is a standalone JSON Schema document — the exact value of
-`tools[i].input_schema` from a real `POST /v1/messages` request. No wrapping,
-no transformation, no re-formatting beyond `JSON.stringify(value, null, 2)`
-so diffs across versions stay readable.
+`tools[i].input_schema` from a real `POST /v1/messages` request, written with
+`JSON.stringify(value, null, 2)` so diffs stay readable. No wrapping, no key
+reordering, no other transformation.
 
-The tool's prose description is **not** duplicated here — it lives in
-[`system-prompts/tool-description-<tool>.md`](../system-prompts/) and stays
-the single source of truth for that content.
+The tool's prose description is not duplicated here — it lives in
+[`system-prompts/tool-description-<tool>.md`](../system-prompts/).
 
 ## Source
 
 Captured at the wire level via a local reverse proxy
-([flare](https://github.com/YiRaaaan/flare)) that sits between Claude Code
-and `api.anthropic.com` and records each request body. Because the schema
-comes from the API payload — not from parsing the minified `cli.js` — it is
-not affected by bundler or minifier changes between Claude Code releases.
+([flare](https://github.com/YiRaaaan/flare)) sitting between Claude Code and
+`api.anthropic.com`. Because the schemas come from the API payload rather
+than from parsing `cli.js`, they are independent of bundler/minifier changes
+across Claude Code releases.
 
-## Version and stability
+## Naming
 
-Files in this directory were captured from **v2.1.168**
-(`x-anthropic-billing-header: cc_version=2.1.168.fc4`).
+`<kebab-case-tool-name>.json` — e.g. `bash.json`, `web-fetch.json`,
+`ask-user-question.json`. The tool name is in the filename only; the file
+body is the schema itself.
 
-As a small data point on the maintenance argument from issue #22: comparing
-captures from **v2.1.161 → v2.1.168** (seven patch releases), **28 of 29
-schemas are byte-identical**. The only change was `LSP`, which gained a new
-`query` property used by the `workspaceSymbol` operation:
+If a layout closer to `system-prompts/tool-description-<tool>.md` is
+preferred (co-located, single dir, `tool-schema-<tool>.json` prefix), the
+files rename cleanly — happy to follow whatever convention the maintainers
+want.
 
-```diff
-+ "query": {
-+   "description": "The symbol name or partial name to search for (workspaceSymbol only). ...",
-+   "type": "string"
-+ }
-```
+## Not covered
 
-That is exactly the kind of change a runtime-contract reader would want to
-know about — and exactly the kind of change that is invisible if only the
-prose description is tracked.
-
-Over the same seven versions, prose descriptions for `AskUserQuestion`,
-`LSP`, `NotebookEdit`, and `Workflow` were edited — confirming that schemas
-and descriptions vary on independent axes.
-
-## Agent invariance
-
-A tool's `input_schema` is identical whether the request comes from the
-main loop, the `Explore` subagent, a `Workflow`-spawned subagent, or any
-other context Claude Code uses. Comparing 188+ captures across those
-contexts, every shared tool name (`Bash`, `Read`, `LSP`, …) produces the
-same byte-for-byte schema. Subagents differ from the main loop only in
-*which* tools are present — typically by subsetting the full list (e.g.
-`Explore` drops `Edit`/`Write`/`NotebookEdit` for its read-only mode and
-drops `Agent`/`Workflow`/`ScheduleWakeup` to prevent recursive spawning).
-
-So one `tool-schemas/<tool>.json` per tool is sufficient — no need to
-partition by caller agent.
-
-## What this directory deliberately does not cover
-
-`StructuredOutput` is a sub-agent-only tool whose `input_schema` is
-**supplied at call time by the caller** (the workflow orchestration
-script that spawned the subagent), not defined by Claude Code itself.
-Across 188 captures, two unrelated `StructuredOutput` schemas appeared:
-one with `{module, purpose, key_files, notable}`, another with
-`{problem, design, rfc, priority, cloud_impact}`. Recording one fixed
-schema here would misrepresent it. Its prose `description`, however, is
-static and could fit naturally into `system-prompts/` if desired.
-
-## Naming convention
-
-- File: `<kebab-case-tool-name>.json`, e.g. `bash.json`, `web-fetch.json`,
-  `ask-user-question.json`, mirroring the `tool-description-<kebab>.md`
-  convention already used in `system-prompts/`.
-- The tool name appears in the filename only; the file body is the schema
-  itself.
-
-## Relationship to the existing extractor
-
-This directory is intentionally decoupled from
-[`tools/updatePrompts.js`](../tools/updatePrompts.js) and the upstream
-[`tweakcc` extractor](https://github.com/Piebald-AI/tweakcc/blob/main/tools/promptExtractor.js).
-Those tools walk the Claude Code AST looking for `StringLiteral` /
-`TemplateLiteral` nodes that pass a "looks like a prompt" heuristic — that
-heuristic cannot match an `ObjectExpression` JSON schema and would need a
-separate identifier+correlation step to associate each schema with its
-tool. The proxy-capture path avoids that entirely; nothing in this
-directory needs the existing extractor to keep working, and nothing in the
-existing extractor needs to know about this directory.
+`StructuredOutput`, a sub-agent tool whose `input_schema` is supplied at
+spawn time by the caller rather than defined by Claude Code, has no fixed
+shape to record.

--- a/tool-schemas/README.md
+++ b/tool-schemas/README.md
@@ -33,11 +33,10 @@ The tool's prose description is not duplicated here — it lives in
 
 ## Source
 
-Captured at the wire level via a local reverse proxy
-([flare](https://github.com/YiRaaaan/flare)) sitting between Claude Code and
-`api.anthropic.com`. Because the schemas come from the API payload rather
-than from parsing `cli.js`, they are independent of bundler/minifier changes
-across Claude Code releases.
+Captured at the wire level via a local reverse proxy sitting between
+Claude Code and `api.anthropic.com`. Because the schemas come from the API
+payload rather than from parsing `cli.js`, they are independent of
+bundler/minifier changes across Claude Code releases.
 
 ## Naming
 

--- a/tool-schemas/README.md
+++ b/tool-schemas/README.md
@@ -5,7 +5,11 @@ the API request body Claude Code sends to Anthropic.
 
 Seeded from issue
 [#22](https://github.com/Piebald-AI/claude-code-system-prompts/issues/22).
-Covers the 29 tools shipped to the main agent loop.
+Covers the 29 tools shipped to the main agent loop in a standard Claude
+Code session. Tools that only appear under specific feature flags (Agent
+Teams / Cowork, computer-use, claude.ai/design, PowerShell on Windows,
+etc.) are out of scope for this initial PR — they need a capture from
+that context.
 
 ## File contents
 

--- a/tool-schemas/README.md
+++ b/tool-schemas/README.md
@@ -51,6 +51,31 @@ Over the same seven versions, prose descriptions for `AskUserQuestion`,
 `LSP`, `NotebookEdit`, and `Workflow` were edited — confirming that schemas
 and descriptions vary on independent axes.
 
+## Agent invariance
+
+A tool's `input_schema` is identical whether the request comes from the
+main loop, the `Explore` subagent, a `Workflow`-spawned subagent, or any
+other context Claude Code uses. Comparing 188+ captures across those
+contexts, every shared tool name (`Bash`, `Read`, `LSP`, …) produces the
+same byte-for-byte schema. Subagents differ from the main loop only in
+*which* tools are present — typically by subsetting the full list (e.g.
+`Explore` drops `Edit`/`Write`/`NotebookEdit` for its read-only mode and
+drops `Agent`/`Workflow`/`ScheduleWakeup` to prevent recursive spawning).
+
+So one `tool-schemas/<tool>.json` per tool is sufficient — no need to
+partition by caller agent.
+
+## What this directory deliberately does not cover
+
+`StructuredOutput` is a sub-agent-only tool whose `input_schema` is
+**supplied at call time by the caller** (the workflow orchestration
+script that spawned the subagent), not defined by Claude Code itself.
+Across 188 captures, two unrelated `StructuredOutput` schemas appeared:
+one with `{module, purpose, key_files, notable}`, another with
+`{problem, design, rfc, priority, cloud_impact}`. Recording one fixed
+schema here would misrepresent it. Its prose `description`, however, is
+static and could fit naturally into `system-prompts/` if desired.
+
 ## Naming convention
 
 - File: `<kebab-case-tool-name>.json`, e.g. `bash.json`, `web-fetch.json`,

--- a/tool-schemas/README.md
+++ b/tool-schemas/README.md
@@ -1,0 +1,73 @@
+# Tool Schemas
+
+JSON `input_schema` for Claude Code's builtin tools, captured verbatim from
+the API request body Claude Code sends to Anthropic.
+
+Seeded from issue
+[#22](https://github.com/Piebald-AI/system-prompts/issues/22). All 29 tools
+shipped in Claude Code v2.1.168 are covered.
+
+## What's in each file
+
+Each `<tool>.json` is a standalone JSON Schema document — the exact value of
+`tools[i].input_schema` from a real `POST /v1/messages` request. No wrapping,
+no transformation, no re-formatting beyond `JSON.stringify(value, null, 2)`
+so diffs across versions stay readable.
+
+The tool's prose description is **not** duplicated here — it lives in
+[`system-prompts/tool-description-<tool>.md`](../system-prompts/) and stays
+the single source of truth for that content.
+
+## Source
+
+Captured at the wire level via a local reverse proxy
+([flare](https://github.com/YiRaaaan/flare)) that sits between Claude Code
+and `api.anthropic.com` and records each request body. Because the schema
+comes from the API payload — not from parsing the minified `cli.js` — it is
+not affected by bundler or minifier changes between Claude Code releases.
+
+## Version and stability
+
+Files in this directory were captured from **v2.1.168**
+(`x-anthropic-billing-header: cc_version=2.1.168.fc4`).
+
+As a small data point on the maintenance argument from issue #22: comparing
+captures from **v2.1.161 → v2.1.168** (seven patch releases), **28 of 29
+schemas are byte-identical**. The only change was `LSP`, which gained a new
+`query` property used by the `workspaceSymbol` operation:
+
+```diff
++ "query": {
++   "description": "The symbol name or partial name to search for (workspaceSymbol only). ...",
++   "type": "string"
++ }
+```
+
+That is exactly the kind of change a runtime-contract reader would want to
+know about — and exactly the kind of change that is invisible if only the
+prose description is tracked.
+
+Over the same seven versions, prose descriptions for `AskUserQuestion`,
+`LSP`, `NotebookEdit`, and `Workflow` were edited — confirming that schemas
+and descriptions vary on independent axes.
+
+## Naming convention
+
+- File: `<kebab-case-tool-name>.json`, e.g. `bash.json`, `web-fetch.json`,
+  `ask-user-question.json`, mirroring the `tool-description-<kebab>.md`
+  convention already used in `system-prompts/`.
+- The tool name appears in the filename only; the file body is the schema
+  itself.
+
+## Relationship to the existing extractor
+
+This directory is intentionally decoupled from
+[`tools/updatePrompts.js`](../tools/updatePrompts.js) and the upstream
+[`tweakcc` extractor](https://github.com/Piebald-AI/tweakcc/blob/main/tools/promptExtractor.js).
+Those tools walk the Claude Code AST looking for `StringLiteral` /
+`TemplateLiteral` nodes that pass a "looks like a prompt" heuristic — that
+heuristic cannot match an `ObjectExpression` JSON schema and would need a
+separate identifier+correlation step to associate each schema with its
+tool. The proxy-capture path avoids that entirely; nothing in this
+directory needs the existing extractor to keep working, and nothing in the
+existing extractor needs to know about this directory.

--- a/tool-schemas/README.md
+++ b/tool-schemas/README.md
@@ -6,18 +6,20 @@ the API request body Claude Code sends to Anthropic.
 Seeded from issue
 [#22](https://github.com/Piebald-AI/claude-code-system-prompts/issues/22).
 
-- **29 default tools** shipped to the main agent loop in a standard
-  Claude Code session (`bash.json`, `read.json`, `edit.json`, …).
-- **3 Agent Teams tools** (`send-message.json`, `team-create.json`,
-  `team-delete.json`) captured under
-  `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` / `--agent-teams`. These
-  appear in the `tools[]` payload only when that gate is enabled
-  (`utils/agentSwarmsEnabled.ts`).
+35 schemas total, grouped by how they surface in the `tools[]` payload:
 
-Other build-time-gated tools (`SendUserFile`, `Snip`, `WebBrowser`, …
-behind `feature('KAIROS')` etc.) are not in the public npm bundle and so
-cannot be captured from a standard install; PowerShell needs a Windows
-host. Those remain out of scope for this PR.
+| Group | Tools | How to surface |
+|---|---|---|
+| **Default main loop** (29) | `agent`, `ask-user-question`, `bash`, `cron-*`, `edit`, `enter-/exit-plan-mode`, `enter-/exit-worktree`, `lsp`, `monitor`, `notebook-edit`, `push-notification`, `read`, `remote-trigger`, `schedule-wakeup`, `skill`, `task-*`, `web-fetch`, `web-search`, `workflow`, `write` | Standard Claude Code session, no flags |
+| **Agent Teams** (3) | `send-message`, `team-create`, `team-delete` | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or `--agent-teams` (`utils/agentSwarmsEnabled.ts`) |
+| **`local-agent` entrypoint** (2) | `glob`, `grep` | `CLAUDE_CODE_ENTRYPOINT=local-agent` (sub-agent context that exposes the dedicated search tools instead of having the model shell out via `Bash`) |
+| **Brief / assistant mode** (1) | `send-user-message` | `CLAUDE_CODE_BRIEF=1` (KAIROS-style assistant entrypoint) |
+
+Build-time-gated tools (`SendUserFile`, `Snip`, `WebBrowser`, …) live
+behind `bun:bundle` `feature('KAIROS')` / `feature('WEB_BROWSER_TOOL')`
+macros. Their code is present in the public native binary but they
+require additional runtime gates not exposed by the env flags above;
+left for a follow-up PR. `PowerShell` is Windows-only.
 
 ## File contents
 

--- a/tool-schemas/README.md
+++ b/tool-schemas/README.md
@@ -28,8 +28,9 @@ Each `<tool>.json` is a standalone JSON Schema document — the exact value of
 `JSON.stringify(value, null, 2)` so diffs stay readable. No wrapping, no key
 reordering, no other transformation.
 
-The tool's prose description is not duplicated here — it lives in
-[`system-prompts/tool-description-<tool>.md`](../system-prompts/).
+The tool's prose description is not duplicated here — it lives in the
+[`system-prompts/`](../system-prompts/) directory (files matching
+`tool-description-<tool>*.md`).
 
 ## Source
 

--- a/tool-schemas/agent.json
+++ b/tool-schemas/agent.json
@@ -18,7 +18,8 @@
       "enum": [
         "sonnet",
         "opus",
-        "haiku"
+        "haiku",
+        "fable"
       ],
       "type": "string"
     },

--- a/tool-schemas/agent.json
+++ b/tool-schemas/agent.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "description": {
+      "description": "A short (3-5 word) description of the task",
+      "type": "string"
+    },
+    "isolation": {
+      "description": "Isolation mode. \"worktree\" creates a temporary git worktree so the agent works on an isolated copy of the repo.",
+      "enum": [
+        "worktree"
+      ],
+      "type": "string"
+    },
+    "model": {
+      "description": "Optional model override for this agent. Takes precedence over the agent definition's model frontmatter. If omitted, uses the agent definition's model, or inherits from the parent.",
+      "enum": [
+        "sonnet",
+        "opus",
+        "haiku"
+      ],
+      "type": "string"
+    },
+    "prompt": {
+      "description": "The task for the agent to perform",
+      "type": "string"
+    },
+    "run_in_background": {
+      "description": "Set to true to run this agent in the background. You will be notified when it completes.",
+      "type": "boolean"
+    },
+    "subagent_type": {
+      "description": "The type of specialized agent to use for this task",
+      "type": "string"
+    }
+  },
+  "required": [
+    "description",
+    "prompt"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/ask-user-question.json
+++ b/tool-schemas/ask-user-question.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "annotations": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "notes": {
+            "description": "Free-text notes the user added to their selection.",
+            "type": "string"
+          },
+          "preview": {
+            "description": "The preview content of the selected option, if the question used previews.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "description": "Optional per-question annotations from the user (e.g., notes on preview selections). Keyed by question text.",
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "answers": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "User answers collected by the permission component",
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "metadata": {
+      "additionalProperties": false,
+      "description": "Optional metadata for tracking and analytics purposes. Not displayed to user.",
+      "properties": {
+        "source": {
+          "description": "Optional identifier for the source of this question (e.g., \"remember\" for /remember command). Used for analytics tracking.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "questions": {
+      "description": "Questions to ask the user (1-4 questions)",
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "header": {
+            "description": "Very short label displayed as a chip/tag (max 12 chars). Examples: \"Auth method\", \"Library\", \"Approach\".",
+            "type": "string"
+          },
+          "multiSelect": {
+            "default": false,
+            "description": "Set to true to allow the user to select multiple options instead of just one. Use when choices are not mutually exclusive.",
+            "type": "boolean"
+          },
+          "options": {
+            "description": "The available choices for this question. Must have 2-4 options. Each option should be a distinct, mutually exclusive choice (unless multiSelect is enabled). There should be no 'Other' option, that will be provided automatically.",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "description": "Explanation of what this option means or what will happen if chosen. Useful for providing context about trade-offs or implications.",
+                  "type": "string"
+                },
+                "label": {
+                  "description": "The display text for this option that the user will see and select. Should be concise (1-5 words) and clearly describe the choice.",
+                  "type": "string"
+                },
+                "preview": {
+                  "description": "Optional preview content rendered when this option is focused. Use for mockups, code snippets, or visual comparisons that help users compare options. See the tool description for the expected content format.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "label",
+                "description"
+              ],
+              "type": "object"
+            },
+            "maxItems": 4,
+            "minItems": 2,
+            "type": "array"
+          },
+          "question": {
+            "description": "The complete question to ask the user. Should be clear, specific, and end with a question mark. Example: \"Which library should we use for date formatting?\" If multiSelect is true, phrase it accordingly, e.g. \"Which features do you want to enable?\"",
+            "type": "string"
+          }
+        },
+        "required": [
+          "question",
+          "header",
+          "options",
+          "multiSelect"
+        ],
+        "type": "object"
+      },
+      "maxItems": 4,
+      "minItems": 1,
+      "type": "array"
+    }
+  },
+  "required": [
+    "questions"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/bash.json
+++ b/tool-schemas/bash.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "command": {
+      "description": "The command to execute",
+      "type": "string"
+    },
+    "dangerouslyDisableSandbox": {
+      "description": "Set this to true to dangerously override sandbox mode and run commands without sandboxing.",
+      "type": "boolean"
+    },
+    "description": {
+      "description": "Clear, concise description of what this command does in active voice. Never use words like \"complex\" or \"risk\" in the description - just describe what it does.\n\nFor simple commands (git, npm, standard CLI tools), keep it brief (5-10 words):\n- ls → \"List files in current directory\"\n- git status → \"Show working tree status\"\n- npm install → \"Install package dependencies\"\n\nFor commands that are harder to parse at a glance (piped commands, obscure flags, etc.), add enough context to clarify what it does:\n- find . -name \"*.tmp\" -exec rm {} \\; → \"Find and delete all .tmp files recursively\"\n- git reset --hard origin/main → \"Discard all local changes and match remote main\"\n- curl -s url | jq '.data[]' → \"Fetch JSON from URL and extract data array elements\"",
+      "type": "string"
+    },
+    "run_in_background": {
+      "description": "Set to true to run this command in the background.",
+      "type": "boolean"
+    },
+    "timeout": {
+      "description": "Optional timeout in milliseconds (max 600000)",
+      "type": "number"
+    }
+  },
+  "required": [
+    "command"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/cron-create.json
+++ b/tool-schemas/cron-create.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "cron": {
+      "description": "Standard 5-field cron expression in local time: \"M H DoM Mon DoW\" (e.g. \"*/5 * * * *\" = every 5 minutes, \"30 14 28 2 *\" = Feb 28 at 2:30pm local once).",
+      "type": "string"
+    },
+    "durable": {
+      "description": "true = persist to .claude/scheduled_tasks.json and survive restarts. false (default) = in-memory only, dies when this Claude session ends. Use true only when the user asks the task to survive across sessions.",
+      "type": "boolean"
+    },
+    "prompt": {
+      "description": "The prompt to enqueue at each fire time.",
+      "type": "string"
+    },
+    "recurring": {
+      "description": "true (default) = fire on every cron match until deleted or auto-expired after 7 days. false = fire once at the next match, then auto-delete. Use false for \"remind me at X\" one-shot requests with pinned minute/hour/dom/month.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "cron",
+    "prompt"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/cron-delete.json
+++ b/tool-schemas/cron-delete.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "description": "Job ID returned by CronCreate.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/cron-list.json
+++ b/tool-schemas/cron-list.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "type": "object"
+}

--- a/tool-schemas/edit.json
+++ b/tool-schemas/edit.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "file_path": {
+      "description": "The absolute path to the file to modify",
+      "type": "string"
+    },
+    "new_string": {
+      "description": "The text to replace it with (must be different from old_string)",
+      "type": "string"
+    },
+    "old_string": {
+      "description": "The text to replace",
+      "type": "string"
+    },
+    "replace_all": {
+      "default": false,
+      "description": "Replace all occurrences of old_string (default false)",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "file_path",
+    "old_string",
+    "new_string"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/enter-plan-mode.json
+++ b/tool-schemas/enter-plan-mode.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "type": "object"
+}

--- a/tool-schemas/enter-worktree.json
+++ b/tool-schemas/enter-worktree.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "description": "Optional name for a new worktree. Each \"/\"-separated segment may contain only letters, digits, dots, underscores, and dashes; max 64 chars total. A random name is generated if not provided. Mutually exclusive with `path`.",
+      "type": "string"
+    },
+    "path": {
+      "description": "Path to an existing worktree of the current repository to switch into instead of creating a new one. Must appear in `git worktree list` for the current repo. Mutually exclusive with `name`.",
+      "type": "string"
+    }
+  },
+  "type": "object"
+}

--- a/tool-schemas/exit-plan-mode.json
+++ b/tool-schemas/exit-plan-mode.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": {},
+  "properties": {
+    "allowedPrompts": {
+      "description": "Prompt-based permissions needed to implement the plan. These describe categories of actions rather than specific commands.",
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "prompt": {
+            "description": "Semantic description of the action, e.g. \"run tests\", \"install dependencies\"",
+            "type": "string"
+          },
+          "tool": {
+            "description": "The tool this prompt applies to",
+            "enum": [
+              "Bash"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "tool",
+          "prompt"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "type": "object"
+}

--- a/tool-schemas/exit-worktree.json
+++ b/tool-schemas/exit-worktree.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "action": {
+      "description": "\"keep\" leaves the worktree and branch on disk; \"remove\" deletes both.",
+      "enum": [
+        "keep",
+        "remove"
+      ],
+      "type": "string"
+    },
+    "discard_changes": {
+      "description": "Required true when action is \"remove\" and the worktree has uncommitted files or unmerged commits. The tool will refuse and list them otherwise.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "action"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/glob.json
+++ b/tool-schemas/glob.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "path": {
+      "description": "The directory to search in. If not specified, the current working directory will be used. IMPORTANT: Omit this field to use the default directory. DO NOT enter \"undefined\" or \"null\" - simply omit it for the default behavior. Must be a valid directory path if provided.",
+      "type": "string"
+    },
+    "pattern": {
+      "description": "The glob pattern to match files against",
+      "type": "string"
+    }
+  },
+  "required": [
+    "pattern"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/grep.json
+++ b/tool-schemas/grep.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "-A": {
+      "description": "Number of lines to show after each match (rg -A). Requires output_mode: \"content\", ignored otherwise.",
+      "type": "number"
+    },
+    "-B": {
+      "description": "Number of lines to show before each match (rg -B). Requires output_mode: \"content\", ignored otherwise.",
+      "type": "number"
+    },
+    "-C": {
+      "description": "Alias for context.",
+      "type": "number"
+    },
+    "-i": {
+      "description": "Case insensitive search (rg -i)",
+      "type": "boolean"
+    },
+    "-n": {
+      "description": "Show line numbers in output (rg -n). Requires output_mode: \"content\", ignored otherwise. Defaults to true.",
+      "type": "boolean"
+    },
+    "-o": {
+      "description": "Print only the matched (non-empty) parts of each matching line, one match per output line (rg -o / --only-matching). Requires output_mode: \"content\", ignored otherwise. Defaults to false.",
+      "type": "boolean"
+    },
+    "context": {
+      "description": "Number of lines to show before and after each match (rg -C). Requires output_mode: \"content\", ignored otherwise.",
+      "type": "number"
+    },
+    "glob": {
+      "description": "Glob pattern to filter files (e.g. \"*.js\", \"*.{ts,tsx}\") - maps to rg --glob",
+      "type": "string"
+    },
+    "head_limit": {
+      "description": "Limit output to first N lines/entries, equivalent to \"| head -N\". Works across all output modes: content (limits output lines), files_with_matches (limits file paths), count (limits count entries). Defaults to 250 when unspecified. Pass 0 for unlimited (use sparingly — large result sets waste context).",
+      "type": "number"
+    },
+    "multiline": {
+      "description": "Enable multiline mode where . matches newlines and patterns can span lines (rg -U --multiline-dotall). Default: false.",
+      "type": "boolean"
+    },
+    "offset": {
+      "description": "Skip first N lines/entries before applying head_limit, equivalent to \"| tail -n +N | head -N\". Works across all output modes. Defaults to 0.",
+      "type": "number"
+    },
+    "output_mode": {
+      "description": "Output mode: \"content\" shows matching lines (supports -A/-B/-C context, -n line numbers, head_limit), \"files_with_matches\" shows file paths (supports head_limit), \"count\" shows match counts (supports head_limit). Defaults to \"files_with_matches\".",
+      "enum": [
+        "content",
+        "files_with_matches",
+        "count"
+      ],
+      "type": "string"
+    },
+    "path": {
+      "description": "File or directory to search in (rg PATH). Defaults to current working directory.",
+      "type": "string"
+    },
+    "pattern": {
+      "description": "The regular expression pattern to search for in file contents",
+      "type": "string"
+    },
+    "type": {
+      "description": "File type to search (rg --type). Common types: js, py, rust, go, java, etc. More efficient than include for standard file types.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "pattern"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/lsp.json
+++ b/tool-schemas/lsp.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "character": {
+      "description": "The character offset (1-based, as shown in editors)",
+      "exclusiveMinimum": 0,
+      "maximum": 9007199254740991,
+      "type": "integer"
+    },
+    "filePath": {
+      "description": "The absolute or relative path to the file",
+      "type": "string"
+    },
+    "line": {
+      "description": "The line number (1-based, as shown in editors)",
+      "exclusiveMinimum": 0,
+      "maximum": 9007199254740991,
+      "type": "integer"
+    },
+    "operation": {
+      "description": "The LSP operation to perform",
+      "enum": [
+        "goToDefinition",
+        "findReferences",
+        "hover",
+        "documentSymbol",
+        "workspaceSymbol",
+        "goToImplementation",
+        "prepareCallHierarchy",
+        "incomingCalls",
+        "outgoingCalls"
+      ],
+      "type": "string"
+    },
+    "query": {
+      "description": "The symbol name or partial name to search for (workspaceSymbol only). Most language servers return no results for an empty query, so always provide it when using workspaceSymbol.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "operation",
+    "filePath",
+    "line",
+    "character"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/monitor.json
+++ b/tool-schemas/monitor.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "command": {
+      "description": "Shell command or script. Each stdout line is an event; exit ends the watch.",
+      "type": "string"
+    },
+    "description": {
+      "description": "Short human-readable description of what you are monitoring (shown in notifications).",
+      "type": "string"
+    },
+    "persistent": {
+      "default": false,
+      "description": "Run for the lifetime of the session (no timeout). Use for session-length watches like PR monitoring or log tails. Stop with TaskStop.",
+      "type": "boolean"
+    },
+    "timeout_ms": {
+      "default": 300000,
+      "description": "Kill the monitor after this deadline. Default 300000ms, max 3600000ms. Ignored when persistent is true.",
+      "minimum": 1000,
+      "type": "number"
+    }
+  },
+  "required": [
+    "description",
+    "timeout_ms",
+    "persistent",
+    "command"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/notebook-edit.json
+++ b/tool-schemas/notebook-edit.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "cell_id": {
+      "description": "The ID of the cell to edit. When inserting a new cell, the new cell will be inserted after the cell with this ID, or at the beginning if not specified.",
+      "type": "string"
+    },
+    "cell_type": {
+      "description": "The type of the cell (code or markdown). If not specified, it defaults to the current cell type. If using edit_mode=insert, this is required.",
+      "enum": [
+        "code",
+        "markdown"
+      ],
+      "type": "string"
+    },
+    "edit_mode": {
+      "description": "The type of edit to make (replace, insert, delete). Defaults to replace.",
+      "enum": [
+        "replace",
+        "insert",
+        "delete"
+      ],
+      "type": "string"
+    },
+    "new_source": {
+      "description": "The new source for the cell",
+      "type": "string"
+    },
+    "notebook_path": {
+      "description": "The absolute path to the Jupyter notebook file to edit (must be absolute, not relative)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "notebook_path",
+    "new_source"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/push-notification.json
+++ b/tool-schemas/push-notification.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "message": {
+      "description": "The notification body. Keep it under 200 characters; mobile OSes truncate.",
+      "minLength": 1,
+      "type": "string"
+    },
+    "status": {
+      "const": "proactive",
+      "type": "string"
+    }
+  },
+  "required": [
+    "message",
+    "status"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/read.json
+++ b/tool-schemas/read.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "file_path": {
+      "description": "The absolute path to the file to read",
+      "type": "string"
+    },
+    "limit": {
+      "description": "The number of lines to read. Only provide if the file is too large to read at once.",
+      "exclusiveMinimum": 0,
+      "maximum": 9007199254740991,
+      "type": "integer"
+    },
+    "offset": {
+      "description": "The line number to start reading from. Only provide if the file is too large to read at once",
+      "maximum": 9007199254740991,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "pages": {
+      "description": "Page range for PDF files (e.g., \"1-5\", \"3\", \"10-20\"). Only applicable to PDF files. Maximum 20 pages per request.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "file_path"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/remote-trigger.json
+++ b/tool-schemas/remote-trigger.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "action": {
+      "enum": [
+        "list",
+        "get",
+        "create",
+        "update",
+        "run"
+      ],
+      "type": "string"
+    },
+    "body": {
+      "additionalProperties": {},
+      "description": "Required for create and update; optional for run",
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "trigger_id": {
+      "description": "Required for get, update, and run",
+      "pattern": "^[\\w-]+$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "action"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/schedule-wakeup.json
+++ b/tool-schemas/schedule-wakeup.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "delaySeconds": {
+      "description": "Seconds from now to wake up. Clamped to [60, 3600] by the runtime.",
+      "type": "number"
+    },
+    "prompt": {
+      "description": "The /loop input to fire on wake-up. Pass the same /loop input verbatim each turn so the next firing re-enters the skill and continues the loop. For autonomous /loop (no user prompt), pass the literal sentinel `<<autonomous-loop-dynamic>>` instead (the dynamic-pacing variant, not the CronCreate-mode `<<autonomous-loop>>`).",
+      "type": "string"
+    },
+    "reason": {
+      "description": "One short sentence explaining the chosen delay. Goes to telemetry and is shown to the user. Be specific.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "delaySeconds",
+    "reason",
+    "prompt"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/send-message.json
+++ b/tool-schemas/send-message.json
@@ -36,6 +36,7 @@
                   "type": "string"
                 },
                 "request_id": {
+                  "pattern": "^[^\\n\\r]{1,200}$",
                   "type": "string"
                 },
                 "type": {
@@ -60,6 +61,7 @@
                   "type": "string"
                 },
                 "request_id": {
+                  "pattern": "^[^\\n\\r]{1,200}$",
                   "type": "string"
                 },
                 "type": {
@@ -80,6 +82,7 @@
     },
     "summary": {
       "description": "A 5-10 word summary shown as a preview in the UI (required when message is a string)",
+      "maxLength": 200,
       "type": "string"
     },
     "to": {

--- a/tool-schemas/send-message.json
+++ b/tool-schemas/send-message.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "message": {
+      "anyOf": [
+        {
+          "description": "Plain text message content",
+          "type": "string"
+        },
+        {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "reason": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "shutdown_request",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "approve": {
+                  "type": "boolean"
+                },
+                "reason": {
+                  "type": "string"
+                },
+                "request_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "shutdown_response",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "request_id",
+                "approve"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "approve": {
+                  "type": "boolean"
+                },
+                "feedback": {
+                  "type": "string"
+                },
+                "request_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "plan_approval_response",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "request_id",
+                "approve"
+              ],
+              "type": "object"
+            }
+          ]
+        }
+      ]
+    },
+    "summary": {
+      "description": "A 5-10 word summary shown as a preview in the UI (required when message is a string)",
+      "type": "string"
+    },
+    "to": {
+      "description": "Recipient: teammate name",
+      "type": "string"
+    }
+  },
+  "required": [
+    "to",
+    "message"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/send-user-message.json
+++ b/tool-schemas/send-user-message.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "attachments": {
+      "description": "Optional attachments for the user to see alongside your message. Each entry is either a file path (absolute or relative to cwd) for a file you can read locally, or a pre-resolved {file_uuid, file_name, size, is_image} object you obtained from a device tool such as attach_file.",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "additionalProperties": false,
+            "description": "A file already uploaded to the filestore (e.g. by the device attach_file tool). Passed through without local stat or upload.",
+            "properties": {
+              "file_name": {
+                "type": "string"
+              },
+              "file_uuid": {
+                "type": "string"
+              },
+              "is_image": {
+                "type": "boolean"
+              },
+              "media_type": {
+                "type": "string"
+              },
+              "size": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "file_uuid",
+              "file_name",
+              "size",
+              "is_image"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "message": {
+      "description": "The message for the user. Supports markdown formatting.",
+      "type": "string"
+    },
+    "status": {
+      "description": "Use 'proactive' when you're surfacing something the user hasn't asked for and needs to see now — task completion while they're away, a blocker you hit, an unsolicited status update. Use 'normal' when replying to something the user just said.",
+      "enum": [
+        "normal",
+        "proactive"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "message",
+    "status"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/skill.json
+++ b/tool-schemas/skill.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "args": {
+      "description": "Optional arguments for the skill",
+      "type": "string"
+    },
+    "skill": {
+      "description": "The name of a skill from the available-skills list. Do not guess names.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "skill"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/task-create.json
+++ b/tool-schemas/task-create.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "activeForm": {
+      "description": "Present continuous form shown in spinner when in_progress (e.g., \"Running tests\")",
+      "type": "string"
+    },
+    "description": {
+      "description": "What needs to be done",
+      "type": "string"
+    },
+    "metadata": {
+      "additionalProperties": {},
+      "description": "Arbitrary metadata to attach to the task",
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "subject": {
+      "description": "A brief title for the task",
+      "type": "string"
+    }
+  },
+  "required": [
+    "subject",
+    "description"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/task-get.json
+++ b/tool-schemas/task-get.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "taskId": {
+      "description": "The ID of the task to retrieve",
+      "type": "string"
+    }
+  },
+  "required": [
+    "taskId"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/task-list.json
+++ b/tool-schemas/task-list.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "type": "object"
+}

--- a/tool-schemas/task-output.json
+++ b/tool-schemas/task-output.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "block": {
+      "default": true,
+      "description": "Whether to wait for completion",
+      "type": "boolean"
+    },
+    "task_id": {
+      "description": "The task ID to get output from",
+      "type": "string"
+    },
+    "timeout": {
+      "default": 30000,
+      "description": "Max wait time in ms",
+      "maximum": 600000,
+      "minimum": 0,
+      "type": "number"
+    }
+  },
+  "required": [
+    "task_id",
+    "block",
+    "timeout"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/task-stop.json
+++ b/tool-schemas/task-stop.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "shell_id": {
+      "description": "Deprecated: use task_id instead",
+      "type": "string"
+    },
+    "task_id": {
+      "description": "The ID of the background task to stop",
+      "type": "string"
+    }
+  },
+  "type": "object"
+}

--- a/tool-schemas/task-update.json
+++ b/tool-schemas/task-update.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "activeForm": {
+      "description": "Present continuous form shown in spinner when in_progress (e.g., \"Running tests\")",
+      "type": "string"
+    },
+    "addBlockedBy": {
+      "description": "Task IDs that block this task",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "addBlocks": {
+      "description": "Task IDs that this task blocks",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "description": {
+      "description": "New description for the task",
+      "type": "string"
+    },
+    "metadata": {
+      "additionalProperties": {},
+      "description": "Metadata keys to merge into the task. Set a key to null to delete it.",
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "owner": {
+      "description": "New owner for the task",
+      "type": "string"
+    },
+    "status": {
+      "anyOf": [
+        {
+          "enum": [
+            "pending",
+            "in_progress",
+            "completed"
+          ],
+          "type": "string"
+        },
+        {
+          "const": "deleted",
+          "type": "string"
+        }
+      ],
+      "description": "New status for the task"
+    },
+    "subject": {
+      "description": "New subject for the task",
+      "type": "string"
+    },
+    "taskId": {
+      "description": "The ID of the task to update",
+      "type": "string"
+    }
+  },
+  "required": [
+    "taskId"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/team-create.json
+++ b/tool-schemas/team-create.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "agent_type": {
+      "description": "Type/role of the team lead (e.g., \"researcher\", \"test-runner\"). Used for team file and inter-agent coordination.",
+      "type": "string"
+    },
+    "description": {
+      "description": "Team description/purpose.",
+      "type": "string"
+    },
+    "team_name": {
+      "description": "Name for the new team to create.",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "team_name"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/team-delete.json
+++ b/tool-schemas/team-delete.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "type": "object"
+}

--- a/tool-schemas/web-fetch.json
+++ b/tool-schemas/web-fetch.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "prompt": {
+      "description": "The prompt to run on the fetched content",
+      "type": "string"
+    },
+    "url": {
+      "description": "The URL to fetch content from",
+      "format": "uri",
+      "type": "string"
+    }
+  },
+  "required": [
+    "url",
+    "prompt"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/web-search.json
+++ b/tool-schemas/web-search.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "allowed_domains": {
+      "description": "Only include search results from these domains",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "blocked_domains": {
+      "description": "Never include search results from these domains",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "query": {
+      "description": "The search query to use",
+      "minLength": 2,
+      "type": "string"
+    }
+  },
+  "required": [
+    "query"
+  ],
+  "type": "object"
+}

--- a/tool-schemas/workflow.json
+++ b/tool-schemas/workflow.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "args": {
+      "description": "Optional input value exposed to the script as the global `args`, verbatim. Pass arrays/objects as actual JSON values, NOT as a JSON-encoded string — a stringified list breaks `args.filter`/`args.map` in the script. Use for parameterized named workflows (e.g. a research question)."
+    },
+    "description": {
+      "description": "Ignored — set the workflow description in the script's `meta` block.",
+      "type": "string"
+    },
+    "name": {
+      "description": "Name of a predefined workflow (built-in or from .claude/workflows/). Resolves to a self-contained script.",
+      "type": "string"
+    },
+    "resumeFromRunId": {
+      "description": "Run ID of a prior Workflow invocation to resume from. Completed agent() calls with unchanged (prompt, opts) return their cached results instantly; only edited or new calls re-run. Same-session only. Stop the prior run first (TaskStop) before resuming.",
+      "pattern": "^wf_[a-z0-9-]{6,}$",
+      "type": "string"
+    },
+    "script": {
+      "description": "Self-contained workflow script. Must begin with `export const meta = { name, description, phases }` (pure literal, no computed values) followed by the script body using agent()/parallel()/pipeline()/phase().",
+      "maxLength": 524288,
+      "type": "string"
+    },
+    "scriptPath": {
+      "description": "Path to a workflow script file on disk. Every Workflow invocation persists its script under the session directory and returns the path in the tool result. To iterate, edit that file with Write/Edit and re-invoke Workflow with the same `scriptPath` instead of re-sending the full script. Takes precedence over `script` and `name`.",
+      "type": "string"
+    },
+    "title": {
+      "description": "Ignored — set the workflow title in the script's `meta` block.",
+      "type": "string"
+    }
+  },
+  "type": "object"
+}

--- a/tool-schemas/write.json
+++ b/tool-schemas/write.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "content": {
+      "description": "The content to write to the file",
+      "type": "string"
+    },
+    "file_path": {
+      "description": "The absolute path to the file to write (must be absolute, not relative)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "file_path",
+    "content"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
Seeded from #22. Thanks for the welcoming reply there — I went ahead and
captured the full default tool set rather than just Bash, since the data
turned out to make a small but interesting case for the approach.

## What's added

A new top-level `tool-schemas/` directory with 35 standalone JSON Schema
files, each the verbatim value of `tools[i].input_schema` from a real
`POST /v1/messages` request, plus a short README. No transformation, no
key reordering, no wrapping — just `JSON.stringify(value, null, 2)` so
diffs stay readable.

Files are grouped by what surfaces them in `tools[]`:

| Group | Count | How to surface |
|---|---|---|
| Default main loop | 29 | Standard Claude Code session |
| Agent Teams | 3 | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` / `--agent-teams` |
| `local-agent` sub-agent | 2 | `CLAUDE_CODE_ENTRYPOINT=local-agent` (adds `Glob`/`Grep`) |
| Brief / KAIROS assistant | 1 | `CLAUDE_CODE_BRIEF=1` (adds `SendUserMessage`) |

## Stability evidence (relevant to your maintenance-burden concern)

I compared captures from **v2.1.161 through v2.1.168** (seven patch
releases). **28 of 29 default schemas are byte-identical** across that
range. The only change was `LSP`, which gained a new `query` property
for the `workspaceSymbol` operation:

```diff
+ "query": {
+   "description": "The symbol name or partial name to search for (workspaceSymbol only). ...",
+   "type": "string"
+ }
```

That kind of contract change is exactly what schema tracking surfaces
and prose-description tracking cannot. Over the same seven versions,
prose descriptions for `AskUserQuestion`, `LSP`, `NotebookEdit`, and
`Workflow` changed — so schemas and descriptions vary on independent
axes.

## Agent invariance

A given tool's `input_schema` is identical whether the request comes
from the main loop, the `Explore` subagent, a `Workflow`-spawned
subagent, or any other context. Comparing 188+ captures across those,
every shared tool name produces the same byte-for-byte schema.
Subagents differ from the main loop only in *which* tools they get,
not in schema content — so one file per tool is sufficient (no
need to partition by caller).

## Deliberately excluded

`StructuredOutput` — a sub-agent tool whose `input_schema` is supplied
at spawn time by the caller (the workflow orchestration script), not
defined by Claude Code. Captures show two unrelated schemas for it
depending on the workflow; recording a fixed file would misrepresent
the tool.

## Out of scope (left for follow-ups)

- `SendUserFile`, `Snip`, `WebBrowser` — code is present in the public
  native binary but requires a server-side GrowthBook entitlement
  (`tengu_kairos`) not flippable from local env.
- `request_teach_access` — comes from the `mcp__computer-use__*` MCP
  server, requires that server installed and connected.
- `PowerShell` — Windows-only.

## Open questions for you

1. **Naming**: I used `tool-schemas/<kebab>.json` to keep schemas in a
   self-contained directory. If you'd rather mirror `system-prompts/`
   with `tool-schema-<kebab>.json` files inside that same directory,
   the rename is mechanical — happy to do it if you prefer.

2. **Main README integration**: I haven't touched `tools/updatePrompts.js`
   or the main `README.md` listing — those are wired to your
   `prompts-X.X.X.json` extractor, which uses a different input path
   than these schemas. If you'd like the schemas to also appear in
   the main README's tool list (with versions / sizes / etc.), happy
   to follow up with a small `updatePrompts.js` patch that scans
   `tool-schemas/` and adds a Tool Schemas section. Kept out of this
   PR to keep one change at a time.

3. **Maintenance**: I'm happy to refresh these on the same cadence
   as your existing extractor — capturing through the proxy is a
   `claude -p` away and the diff per release looks small (often
   empty). Let me know if you'd rather do it yourselves or have me
   send PRs.

## Branch / commit notes

Seven commits, atomic and reviewable in order. The early ones add
the default 29, the middle ones add the gated groups, and the last
slimming-down commits respond to a self-review pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive JSON schemas documenting input contracts for many built-in tools (file ops, tasks, cron, notifications, messaging, web search, LSP, grep, shell, workflows, and more).
  * Added a README describing repo structure, naming/serialization conventions, capture method, schema grouping, and notes on which runtime-provided schemas are excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->