### PR TITLE
Add tools/captureToolSchemas.mjs + main-README listing for tool-schemas/ (follow-up to #24)

### DIFF
--- a/tools/captureToolSchemas.mjs
+++ b/tools/captureToolSchemas.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+// Capture Claude Code's tool `input_schema` values into tool-schemas/<slug>.json
+// by running a tiny intercepting HTTP server, pointing `claude -p` at it via
+// ANTHROPIC_BASE_URL, and pulling `tools[]` out of the POST /v1/messages
+// request body Claude Code sends.
+//
+// The server captures the request body and then replies with a stub auth
+// error — so it never forwards anywhere and doesn't need a valid upstream
+// session. Claude exits immediately on the error, the script collects the
+// captured tools, moves on to the next run, and finally writes one JSON
+// Schema document per tool name to tool-schemas/<slug>.json.
+//
+// Usage:
+//   node tools/captureToolSchemas.mjs
+//
+// Requires:
+//   - `claude` CLI on PATH (Claude Code v2.1.168+).
+//   - Claude Code does not need to actually succeed in talking to Anthropic;
+//     the script just needs Claude Code to *send* its request. So no API key,
+//     no valid OAuth, no network access to Anthropic — anything that lets
+//     `claude -p` get as far as the first POST is enough.
+//
+// What this script produces:
+//   - One file per tool name under tool-schemas/, e.g. `bash.json`,
+//     `ask-user-question.json`, `lsp.json`.
+//   - Four runs cover the four surface conditions the existing PR captures:
+//     default (29), --agent-teams (+3), local-agent entrypoint (+2),
+//     brief / KAIROS (+1).
+//   - StructuredOutput is intentionally skipped — its `input_schema` is
+//     supplied per-call by the workflow that spawned the sub-agent, so
+//     there is no stable shape to record (see tool-schemas/README.md).
+//   - KAIROS-family build-time-gated tools (SendUserFile, WebBrowser, Snip)
+//     and the computer-use MCP tools simply don't appear in `tools[]` on
+//     this binary; the script writes whatever it sees and skips the rest.
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT_DIR = join(__dirname, '..');
+const OUT_DIR = join(ROOT_DIR, 'tool-schemas');
+
+const PORT = Number(process.env.CAPTURE_PORT ?? 4099);
+
+// Inverse of updatePrompts.js's SCHEMA_DISPLAY_NAME_OVERRIDES — when the
+// wire-level tool name doesn't kebab-case mechanically. Add entries here
+// (and the matching override in updatePrompts.js) as future tools appear.
+const NAME_TO_KEBAB_OVERRIDES = {
+  LSP: 'lsp',
+};
+
+function toKebab(name) {
+  if (NAME_TO_KEBAB_OVERRIDES[name]) return NAME_TO_KEBAB_OVERRIDES[name];
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase();
+}
+
+// Sort all object keys lexically so two runs (or two captures) produce
+// byte-stable output. The wire-level payload's emit order is not stable
+// across Claude Code processes — only the content is.
+function sortKeysDeep(value) {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (value === null || typeof value !== 'object') return value;
+  return Object.keys(value)
+    .sort()
+    .reduce((acc, k) => {
+      acc[k] = sortKeysDeep(value[k]);
+      return acc;
+    }, {});
+}
+
+// In-flight capture state for the current run.
+let capturedTools = null;
+
+function startStubServer() {
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      const chunks = [];
+      req.on('data', (c) => chunks.push(c));
+      req.on('end', () => {
+        // Pull tools[] out of the first POST /v1/messages we see this run.
+        if (
+          capturedTools === null &&
+          req.method === 'POST' &&
+          req.url.includes('/v1/messages')
+        ) {
+          try {
+            const parsed = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+            if (Array.isArray(parsed.tools)) capturedTools = parsed.tools;
+          } catch {
+            // not JSON, or no tools — leave capturedTools null
+          }
+        }
+
+        // Stub a 403 so `claude -p` exits immediately. 401 triggers up to
+        // four internal retries; 403 surfaces straight through as
+        // "Failed to authenticate" and the process exits. We don't care
+        // what claude prints — we already have the tools[] in memory.
+        res.writeHead(403, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            type: 'error',
+            error: {
+              type: 'forbidden',
+              message: 'capture stub — tools[] already collected',
+            },
+          }),
+        );
+      });
+    });
+    server.listen(PORT, '127.0.0.1', () => resolve(server));
+  });
+}
+
+function runClaude(extraEnv) {
+  return new Promise((resolve) => {
+    const child = spawn('claude', ['-p', 'ok'], {
+      env: {
+        ...process.env,
+        ANTHROPIC_BASE_URL: `http://127.0.0.1:${PORT}`,
+        ...extraEnv,
+      },
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    // We expect claude to exit non-zero (we stubbed an auth error). Resolve
+    // either way; the capture happened during the request body.
+    child.on('exit', () => resolve());
+    child.on('error', () => resolve());
+  });
+}
+
+async function captureRun(label, extraEnv) {
+  capturedTools = null;
+  process.stdout.write(`  ${label.padEnd(16)} `);
+  await runClaude(extraEnv);
+  if (!capturedTools) {
+    console.log('no tools[] seen');
+    return [];
+  }
+  console.log(`captured ${capturedTools.length}`);
+  return capturedTools;
+}
+
+function writeSchemas(tools) {
+  if (!existsSync(OUT_DIR)) mkdirSync(OUT_DIR, { recursive: true });
+  const written = [];
+  for (const t of tools) {
+    if (!t.name || !t.input_schema) continue;
+    const file = `${toKebab(t.name)}.json`;
+    writeFileSync(
+      join(OUT_DIR, file),
+      JSON.stringify(sortKeysDeep(t.input_schema), null, 2) + '\n',
+    );
+    written.push(file);
+  }
+  return written;
+}
+
+async function main() {
+  console.log(`Listening on http://127.0.0.1:${PORT} (intercept, no upstream)`);
+  const server = await startStubServer();
+
+  const runs = [
+    { label: 'default', env: {} },
+    { label: 'agent-teams', env: { CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1' } },
+    { label: 'local-agent', env: { CLAUDE_CODE_ENTRYPOINT: 'local-agent' } },
+    { label: 'brief', env: { CLAUDE_CODE_BRIEF: '1' } },
+  ];
+
+  try {
+    const merged = new Map();
+    for (const run of runs) {
+      const tools = await captureRun(run.label, run.env);
+      for (const t of tools) {
+        if (!merged.has(t.name)) merged.set(t.name, t);
+      }
+    }
+
+    merged.delete('StructuredOutput');
+
+    const written = writeSchemas([...merged.values()]);
+    console.log(`\nWrote ${written.length} files under ${OUT_DIR}/`);
+  } finally {
+    server.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/captureToolSchemas.mjs
+++ b/tools/captureToolSchemas.mjs
@@ -53,12 +53,22 @@ const NAME_TO_KEBAB_OVERRIDES = {
   LSP: 'lsp',
 };
 
+// Strictly kebab — letters / digits / single hyphens only. Used to guard
+// against unsafe filenames even though tool names come from Claude Code
+// itself; if Claude Code ever emits an unexpected character we want to
+// fail loud rather than silently write to a path we didn't mean to.
+const SAFE_KEBAB = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
 function toKebab(name) {
-  if (NAME_TO_KEBAB_OVERRIDES[name]) return NAME_TO_KEBAB_OVERRIDES[name];
-  return name
-    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
-    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
-    .toLowerCase();
+  const out = NAME_TO_KEBAB_OVERRIDES[name]
+    ?? name
+      .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+      .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+      .toLowerCase();
+  if (!SAFE_KEBAB.test(out)) {
+    throw new Error(`Refusing unsafe filename slug "${out}" derived from tool name "${name}"`);
+  }
+  return out;
 }
 
 // Sort all object keys lexically so two runs (or two captures) produce

--- a/tools/updatePrompts.js
+++ b/tools/updatePrompts.js
@@ -6,11 +6,51 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const ROOT_DIR = join(__dirname, '..');
 const SYSTEM_PROMPTS_DIR = join(ROOT_DIR, 'system-prompts');
+const TOOL_SCHEMAS_DIR = join(ROOT_DIR, 'tool-schemas');
 const README_PATH = join(ROOT_DIR, 'README.md');
 
 // Ensure system-prompts directory exists
 if (!existsSync(SYSTEM_PROMPTS_DIR)) {
   mkdirSync(SYSTEM_PROMPTS_DIR, { recursive: true });
+}
+
+// Tools whose canonical display name is NOT just kebab→PascalCase.
+// Add overrides here when the wire-level tool name doesn't follow that rule.
+const SCHEMA_DISPLAY_NAME_OVERRIDES = {
+  'lsp': 'LSP',
+};
+
+/**
+ * Convert a tool-schemas filename to its display name.
+ * Examples:
+ *   bash.json              → "Bash"
+ *   ask-user-question.json → "AskUserQuestion"
+ *   web-fetch.json         → "WebFetch"
+ *   lsp.json               → "LSP" (via override)
+ */
+function schemaFileToDisplayName(filename) {
+  const stem = filename.replace(/\.json$/, '');
+  if (SCHEMA_DISPLAY_NAME_OVERRIDES[stem]) return SCHEMA_DISPLAY_NAME_OVERRIDES[stem];
+  return stem
+    .split('-')
+    .map(s => s.charAt(0).toUpperCase() + s.slice(1))
+    .join('');
+}
+
+/**
+ * Scan tool-schemas/ and return a sorted list of entries.
+ * Returns [] when the directory doesn't exist, so this is safe to call
+ * before the directory is added to a working copy.
+ */
+function getToolSchemas() {
+  if (!existsSync(TOOL_SCHEMAS_DIR)) return [];
+  return readdirSync(TOOL_SCHEMAS_DIR)
+    .filter(f => f.endsWith('.json'))
+    .sort()
+    .map(filename => ({
+      filename,
+      displayName: schemaFileToDisplayName(filename),
+    }));
 }
 
 // Get API key from environment
@@ -550,6 +590,21 @@ function updateReadme(promptsByFilename, version, releaseDate, versionCount) {
   newLines.push('');
   newLines.push(...categories['Builtin Tool Descriptions']['Additional notes for some Tool Descriptions']);
   newLines.push('');
+
+  // Tool Schemas section — only emitted when `tool-schemas/` exists in the
+  // working tree, so the script remains a no-op for that section on repos
+  // that haven't added the directory yet.
+  const schemas = getToolSchemas();
+  if (schemas.length > 0) {
+    newLines.push('### Tool Schemas');
+    newLines.push('');
+    newLines.push('JSON `input_schema` for each builtin tool, captured verbatim from the Anthropic API payload. See [`tool-schemas/README.md`](./tool-schemas/README.md) for grouping by surface condition.');
+    newLines.push('');
+    for (const s of schemas) {
+      newLines.push(`- [Tool Schema: ${s.displayName}](./tool-schemas/${s.filename})`);
+    }
+    newLines.push('');
+  }
 
   // Write updated README
   writeFileSync(README_PATH, newLines.join('\n'));


### PR DESCRIPTION
Follow-up to #24, as requested in [this comment](https://github.com/Piebald-AI/claude-code-system-prompts/pull/24#issuecomment-by-bl-ue).

Two pieces; you can think of them as "refresh" and "surface":

## 1. `tools/captureToolSchemas.mjs` — one-command schema regeneration

```
node tools/captureToolSchemas.mjs
```

On any machine that has `claude -p` installed, this regenerates the full `tool-schemas/` directory in ~8s. No Anthropic account, no API key, no upstream call. The script runs a tiny intercept server on `127.0.0.1:4099`, spawns `claude -p "ok"` four times with the env that surfaces each gated tool set (default, `--agent-teams`, `local-agent` entrypoint, `brief`/KAIROS), captures `tools[]` out of each request body, and replies with a stub 403 so claude exits immediately without ever talking to Anthropic.

Output is byte-stable across runs (all object keys are lexically sorted) and across machines (no env-dependent code paths). `StructuredOutput` is intentionally skipped — its `input_schema` is supplied per-call by the workflow, see [`tool-schemas/README.md`](../../tree/main/tool-schemas/README.md).

Verified end-to-end on Claude Code v2.1.172 against the schemas committed to #24: 33/35 files reproduce byte-identical; the two deltas are real upstream changes (`agent.json` gained `"fable"` in its model enum; `send-message.json` gained a 200-char `maxLength` plus matching regex on `summary`). Independent fresh-clone smoke test passed: 35/35 valid JSON, ~8.3s wall clock.

## 2. `tools/updatePrompts.js` — main README listing

A small extension so the next time `updatePrompts.js` runs, the main `README.md` will include a `### Tool Schemas` section listing every file in `tool-schemas/`, one bullet per schema, linking to the file.

The new code path is **fully guarded** by `existsSync(TOOL_SCHEMAS_DIR)` — if `tool-schemas/` isn't in the working tree (e.g. on a branch where #24 hasn't merged yet), the script behaves identically to before. So either PR is safe to land before or after the other in any order.

### What the new section looks like

After the existing `### Builtin Tool Descriptions` section, the script will append:

```markdown
### Tool Schemas

JSON `input_schema` for each builtin tool, captured verbatim from the Anthropic API payload. See [`tool-schemas/README.md`](./tool-schemas/README.md) for grouping by surface condition.

- [Tool Schema: Agent](./tool-schemas/agent.json)
- [Tool Schema: AskUserQuestion](./tool-schemas/ask-user-question.json)
- [Tool Schema: Bash](./tool-schemas/bash.json)
…
- [Tool Schema: Workflow](./tool-schemas/workflow.json)
- [Tool Schema: Write](./tool-schemas/write.json)
```

## Why a directory scan, not a JSON-file argument

The existing prompt flow is: `tweakcc/promptExtractor.js` → `prompts-X.X.X.json` → `updatePrompts.js` reads that JSON → writes `system-prompts/*.md`.

Schemas don't have a tweakcc-side extractor — per #24 they're verbatim wire captures committed directly, so the JSON files in `tool-schemas/` are themselves the source of truth. The capture script writes there directly, and `updatePrompts.js` just lists what's present in the README. No intermediate JSON, no second source of truth.

## Implementation notes

**captureToolSchemas.mjs**
- Single file, Node stdlib only (`http`, `https`, `child_process`, `fs`, `path`, `url`). No dependencies.
- `toKebab()` validates its output against `/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/` and throws on any name that wouldn't produce a safe slug (defense in depth against unexpected tool names — see the path-traversal thread on this PR).
- Configurable port via `CAPTURE_PORT` env (default `4099`).

**updatePrompts.js**
- `getToolSchemas()` reads `tool-schemas/`, returns `[]` if absent, else a sorted list of `{filename, displayName}`.
- `schemaFileToDisplayName()` does kebab → PascalCase with one explicit override (`lsp` → `LSP`). New overrides go in `SCHEMA_DISPLAY_NAME_OVERRIDES`; the matching capture-side override is `NAME_TO_KEBAB_OVERRIDES` in `captureToolSchemas.mjs`.

## What this does NOT do

- Does not version-stamp the schemas (no token-counting analog — schemas aren't text content).
- Does not maintain a separate CHANGELOG entry for schema changes — they're captured in the verbatim files themselves and surface naturally in git diffs.
- Does not modify `tweakcc/promptExtractor.js`. Per the design discussion in #24, the schema-capture path stays independent of the prompt-extraction pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * README now includes an auto-generated "Tool Schemas" section that lists available tool schemas when present, with human-friendly display names.

* **Chores**
  * Added a local capture utility that collects tool definitions across runs, consolidates them deterministically, and emits sorted per-tool schema files for documentation and discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->