### PR TITLE
chore: add prompt slimming analysis

### DIFF
--- a/PROMPT_SLIMMING.md
+++ b/PROMPT_SLIMMING.md
@@ -1,0 +1,139 @@
+# Prompt Slimming Candidates
+
+Prompts analyzed: 610
+README token total: 795,823 tokens
+
+## Token Totals By Category
+
+| Category | Prompts | Tokens |
+| --- | ---: | ---: |
+| data | 92 | 325,379 |
+| skill | 81 | 279,892 |
+| agent | 66 | 84,548 |
+| tool | 154 | 49,351 |
+| system | 133 | 44,476 |
+| reminder | 84 | 12,177 |
+
+## Highest Priority Candidates
+
+1. Data: Tool use concepts (11,835 tokens, data-tool-use-concepts.md)
+   - Category: data
+   - Why: very large token footprint; rule-heavy wording; example-heavy content; long checklist shape
+   - Suggested cut: move reference material behind retrieval or an explicit help/docs command; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+2. Skill: Model migration guide (64,238 tokens, skill-model-migration-guide.md)
+   - Category: skill
+   - Why: very large token footprint; many imperative rules; example-heavy content; long checklist shape
+   - Suggested cut: keep a short trigger and load step-specific guidance only after invocation; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+3. Data: Workshop artifact HTML template (46,885 tokens, data-workshop-artifact-html-template.md)
+   - Category: data
+   - Why: very large token footprint; many imperative rules
+   - Suggested cut: move reference material behind retrieval or an explicit help/docs command; deduplicate repeated must/never/always rules into a smaller contract
+4. Skill: Design sync Storybook source shape (25,255 tokens, skill-design-sync-storybook-source-shape.md)
+   - Category: skill
+   - Why: very large token footprint; many imperative rules; example-heavy content; long checklist shape
+   - Suggested cut: keep a short trigger and load step-specific guidance only after invocation; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+5. Skill: /design-sync package source shape (16,174 tokens, skill-design-sync-package-source-shape.md)
+   - Category: skill
+   - Why: very large token footprint; many imperative rules; example-heavy content; long checklist shape
+   - Suggested cut: keep a short trigger and load step-specific guidance only after invocation; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+6. Data: Managed Agents endpoint reference (12,152 tokens, data-managed-agents-endpoint-reference.md)
+   - Category: data
+   - Why: very large token footprint; rule-heavy wording; example-heavy content
+   - Suggested cut: move reference material behind retrieval or an explicit help/docs command; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+7. Skill: Building LLM-powered applications with Claude (27,570 tokens, skill-building-llm-powered-applications-with-claude.md)
+   - Category: skill
+   - Why: very large token footprint; many imperative rules; long checklist shape
+   - Suggested cut: keep a short trigger and load step-specific guidance only after invocation; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+8. Agent Prompt: Security monitor for autonomous agent actions (second part) (25,099 tokens, agent-prompt-security-monitor-for-autonomous-agent-actions-second-part.md)
+   - Category: agent
+   - Why: very large token footprint; many imperative rules; long checklist shape
+   - Suggested cut: keep a short trigger and load step-specific guidance only after invocation; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+9. Skill: /doctor slash command (15,359 tokens, skill-doctor-slash-command.md)
+   - Category: skill
+   - Why: very large token footprint; many imperative rules; long checklist shape
+   - Suggested cut: keep a short trigger and load step-specific guidance only after invocation; deduplicate repeated must/never/always rules into a smaller contract
+10. Skill: Artifact PR review (14,651 tokens, skill-artifact-pr-review.md)
+   - Category: skill
+   - Why: very large token footprint; many imperative rules; long checklist shape
+   - Suggested cut: keep a short trigger and load step-specific guidance only after invocation; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+11. Agent Prompt: Security monitor for autonomous agent actions (first part) (11,418 tokens, agent-prompt-security-monitor-for-autonomous-agent-actions-first-part.md)
+   - Category: agent
+   - Why: very large token footprint; many imperative rules; long checklist shape
+   - Suggested cut: keep a short trigger and load step-specific guidance only after invocation; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+12. Skill: Artifact workshop (10,143 tokens, skill-artifact-workshop.md)
+   - Category: skill
+   - Why: very large token footprint; many imperative rules; example-heavy content
+   - Suggested cut: keep a short trigger and load step-specific guidance only after invocation; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+13. Data: Managed Agents core concepts (8,016 tokens, data-managed-agents-core-concepts.md)
+   - Category: data
+   - Why: large token footprint; rule-heavy wording; example-heavy content
+   - Suggested cut: move reference material behind retrieval or an explicit help/docs command; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+14. Data: Managed Agents tools and skills (7,589 tokens, data-managed-agents-tools-and-skills.md)
+   - Category: data
+   - Why: large token footprint; rule-heavy wording; example-heavy content
+   - Suggested cut: move reference material behind retrieval or an explicit help/docs command; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+15. Data: Managed Agents events and steering (6,639 tokens, data-managed-agents-events-and-steering.md)
+   - Category: data
+   - Why: large token footprint; rule-heavy wording; example-heavy content
+   - Suggested cut: move reference material behind retrieval or an explicit help/docs command; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+16. Data: HTTP error codes reference (4,809 tokens, data-http-error-codes-reference.md)
+   - Category: data
+   - Why: large token footprint; example-heavy content; long checklist shape
+   - Suggested cut: move reference material behind retrieval or an explicit help/docs command; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+17. Data: Plan artifact HTML template (19,011 tokens, data-plan-artifact-html-template.md)
+   - Category: data
+   - Why: very large token footprint
+   - Suggested cut: move reference material behind retrieval or an explicit help/docs command; deduplicate repeated must/never/always rules into a smaller contract
+18. Data: Managed Agents reference — Go (8,273 tokens, data-managed-agents-reference-go.md)
+   - Category: data
+   - Why: large token footprint; example-heavy content
+   - Suggested cut: move reference material behind retrieval or an explicit help/docs command; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+19. Data: Claude API reference — C# (7,997 tokens, data-claude-api-reference-c.md)
+   - Category: data
+   - Why: large token footprint; example-heavy content
+   - Suggested cut: move reference material behind retrieval or an explicit help/docs command; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+20. Data: Tool use reference — TypeScript (7,559 tokens, data-tool-use-reference-typescript.md)
+   - Category: data
+   - Why: large token footprint; example-heavy content
+   - Suggested cut: move reference material behind retrieval or an explicit help/docs command; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+21. Data: Claude API reference — Python (7,423 tokens, data-claude-api-reference-python.md)
+   - Category: data
+   - Why: large token footprint; example-heavy content
+   - Suggested cut: move reference material behind retrieval or an explicit help/docs command; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+22. Data: Tool use reference — Python (7,076 tokens, data-tool-use-reference-python.md)
+   - Category: data
+   - Why: large token footprint; example-heavy content
+   - Suggested cut: move reference material behind retrieval or an explicit help/docs command; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+23. Data: Managed Agents reference — Java (6,740 tokens, data-managed-agents-reference-java.md)
+   - Category: data
+   - Why: large token footprint; example-heavy content
+   - Suggested cut: move reference material behind retrieval or an explicit help/docs command; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+24. Data: Prompt Caching — Design & Optimization (6,056 tokens, data-prompt-caching-design-optimization.md)
+   - Category: data
+   - Why: large token footprint; example-heavy content
+   - Suggested cut: move reference material behind retrieval or an explicit help/docs command; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+25. System Prompt: Coordinator mode orchestration (5,916 tokens, system-prompt-coordinator-mode-orchestration.md)
+   - Category: system
+   - Why: large token footprint; rule-heavy wording; example-heavy content; long checklist shape
+   - Suggested cut: keep only global invariants in the prompt and move situational policy to runtime state; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+26. Data: Claude API reference — TypeScript (5,854 tokens, data-claude-api-reference-typescript.md)
+   - Category: data
+   - Why: large token footprint; example-heavy content
+   - Suggested cut: move reference material behind retrieval or an explicit help/docs command; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+27. Data: Managed Agents reference — PHP (5,420 tokens, data-managed-agents-reference-php.md)
+   - Category: data
+   - Why: large token footprint; example-heavy content
+   - Suggested cut: move reference material behind retrieval or an explicit help/docs command; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+28. Data: Claude API reference — Java (4,844 tokens, data-claude-api-reference-java.md)
+   - Category: data
+   - Why: large token footprint; example-heavy content
+   - Suggested cut: move reference material behind retrieval or an explicit help/docs command; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+29. Skill: Cowork plugin authoring (4,791 tokens, skill-cowork-plugin-authoring.md)
+   - Category: skill
+   - Why: large token footprint; rule-heavy wording; example-heavy content; long checklist shape
+   - Suggested cut: keep a short trigger and load step-specific guidance only after invocation; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+30. Data: Anthropic CLI (4,615 tokens, data-anthropic-cli.md)
+   - Category: data
+   - Why: large token footprint; example-heavy content
+   - Suggested cut: move reference material behind retrieval or an explicit help/docs command; collapse examples into one canonical positive case plus one failure case; deduplicate repeated must/never/always rules into a smaller contract
+

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ The result&mdash;500+ strings that are constantly changing and moving within a v
 
 This repository contains the system prompts extracted using a script from the latest npm version of Claude Code.  As they're extracted directly from Claude Code's compiled source code, they're guaranteed to be exactly what Claude Code uses.  If you use [tweakcc](https://github.com/Piebald-AI/tweakcc) to customize the system prompts, it works in a similar way&mdash;it patches the exact same strings in your local installation as are extracted into this repository.
 
+## Prompt Slimming Analysis
+
+The extracted prompt files are reference material and should not be edited directly. To identify prompt weight that could move out of always-on context, run:
+
+```bash
+node tools/suggestPromptSlimming.mjs --limit 30
+```
+
+The analyzer ranks prompts by token footprint and structural signals such as rule-heavy wording, long checklist shape, and example-heavy content. Its suggested cuts favor moving reference material behind retrieval or explicit help commands, keeping skill prompts lazy-loaded, and replacing verbose tool prose with clearer schemas, validation, and concise runtime errors. The current generated snapshot is in [PROMPT_SLIMMING.md](./PROMPT_SLIMMING.md).
+
 ## Prompts
 
 Note that some prompts contain interpolated bits such as builtin tool name references, lists of available sub agents, and various other context-specific variables, so the actual counts in a particular Claude Code session will differ slightly&mdash;likely not beyond ±20 tokens, however.

--- a/tools/promptSlimmingAnalysis.mjs
+++ b/tools/promptSlimmingAnalysis.mjs
@@ -1,0 +1,242 @@
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+import { parseYamlString } from './promptMarkdownUtils.mjs';
+
+const README_TOKEN_ENTRY =
+  /- \[(?:\*\*)?([^\]]+?)(?:\*\*)?\]\(\.\/system-prompts\/([^)]+\.md)\)\s*\(\*\*(\d+)\*\*\s*tks\)/g;
+
+const PROMPT_CATEGORIES = [
+  ['Agent Prompt: ', 'agent'],
+  ['System Prompt: ', 'system'],
+  ['System Reminder: ', 'reminder'],
+  ['Tool Description: ', 'tool'],
+  ['Tool Parameter: ', 'tool'],
+  ['Data: ', 'data'],
+  ['Skill: ', 'skill'],
+];
+
+const IMPERATIVE_PATTERNS = [
+  /\bmust\b/gi,
+  /\bnever\b/gi,
+  /\balways\b/gi,
+  /\bdo not\b/gi,
+  /\bdon't\b/gi,
+  /\brequired\b/gi,
+  /\bshould\b/gi,
+];
+
+const EXAMPLE_PATTERNS = [
+  /\bfor example\b/gi,
+  /\bexamples?:\b/gi,
+  /```/g,
+  /\be\.g\.\b/gi,
+];
+
+export function parseReadmeTokenCounts(readmeContent) {
+  const counts = new Map();
+  let match;
+  while ((match = README_TOKEN_ENTRY.exec(readmeContent)) !== null) {
+    counts.set(match[2], {
+      name: match[1],
+      filename: match[2],
+      tokens: Number.parseInt(match[3], 10),
+    });
+  }
+  README_TOKEN_ENTRY.lastIndex = 0;
+  return counts;
+}
+
+export function parsePromptMarkdown(content) {
+  const commentMatch = content.match(/^<!--\n([\s\S]*?)\n-->\n?/);
+  if (!commentMatch) {
+    return {
+      name: null,
+      description: null,
+      body: content,
+    };
+  }
+
+  const metadata = commentMatch[1];
+  const nameMatch = metadata.match(/^name:\s*(.+)$/m);
+  const descriptionMatch = metadata.match(/^description:\s*(.+)$/m);
+
+  return {
+    name: nameMatch ? parseYamlString(nameMatch[1]) : null,
+    description: descriptionMatch ? parseYamlString(descriptionMatch[1]) : null,
+    body: content.slice(commentMatch[0].length),
+  };
+}
+
+export function promptCategory(name) {
+  const prefix = PROMPT_CATEGORIES.find(([candidate]) =>
+    String(name || '').startsWith(candidate)
+  );
+  return prefix ? prefix[1] : 'other';
+}
+
+function countMatches(patterns, text) {
+  return patterns.reduce((total, pattern) => {
+    const matches = text.match(pattern);
+    return total + (matches ? matches.length : 0);
+  }, 0);
+}
+
+function bodyMetrics(body) {
+  const lines = body.split('\n');
+  const nonEmptyLines = lines.filter((line) => line.trim().length > 0);
+  const bulletLines = lines.filter((line) => /^\s*(?:[-*]|\d+\.)\s+/.test(line));
+
+  return {
+    chars: body.length,
+    lines: nonEmptyLines.length,
+    bulletLines: bulletLines.length,
+    imperativeCount: countMatches(IMPERATIVE_PATTERNS, body),
+    exampleCount: countMatches(EXAMPLE_PATTERNS, body),
+  };
+}
+
+export function classifyPrompt(prompt) {
+  const category = promptCategory(prompt.name);
+  const metrics = bodyMetrics(prompt.body);
+  const tokens = prompt.tokens || 0;
+  const reasons = [];
+  const actions = [];
+  let priority = 0;
+
+  if (tokens >= 10_000) {
+    priority += 5;
+    reasons.push('very large token footprint');
+  } else if (tokens >= 4_000) {
+    priority += 4;
+    reasons.push('large token footprint');
+  } else if (tokens >= 1_000) {
+    priority += 2;
+    reasons.push('moderate token footprint');
+  }
+
+  if (metrics.imperativeCount >= 40) {
+    priority += 2;
+    reasons.push('many imperative rules');
+  } else if (metrics.imperativeCount >= 15) {
+    priority += 1;
+    reasons.push('rule-heavy wording');
+  }
+
+  if (metrics.exampleCount >= 8) {
+    priority += 1;
+    reasons.push('example-heavy content');
+  }
+
+  if (metrics.bulletLines >= 40) {
+    priority += 1;
+    reasons.push('long checklist shape');
+  }
+
+  if (category === 'data') {
+    priority += tokens >= 1_000 ? 2 : 0;
+    actions.push('move reference material behind retrieval or an explicit help/docs command');
+  } else if (category === 'skill' || category === 'agent') {
+    actions.push('keep a short trigger and load step-specific guidance only after invocation');
+  } else if (category === 'tool') {
+    actions.push('replace prose rules with clearer tool schema, validation, and concise errors');
+  } else if (category === 'system' || category === 'reminder') {
+    actions.push('keep only global invariants in the prompt and move situational policy to runtime state');
+  }
+
+  if (metrics.exampleCount > 0) {
+    actions.push('collapse examples into one canonical positive case plus one failure case');
+  }
+  if (metrics.imperativeCount > 0) {
+    actions.push('deduplicate repeated must/never/always rules into a smaller contract');
+  }
+
+  return {
+    ...prompt,
+    category,
+    metrics,
+    priority,
+    reasons,
+    actions: [...new Set(actions)],
+  };
+}
+
+export function analyzePrompts({ promptsDir, readmePath, limit = 30 }) {
+  const readme = readFileSync(readmePath, 'utf8');
+  const tokenCounts = parseReadmeTokenCounts(readme);
+  const prompts = [];
+
+  for (const filename of readdirSync(promptsDir).filter((file) => file.endsWith('.md'))) {
+    const content = readFileSync(join(promptsDir, filename), 'utf8');
+    const parsed = parsePromptMarkdown(content);
+    const tokenEntry = tokenCounts.get(filename);
+    prompts.push(
+      classifyPrompt({
+        filename,
+        name: parsed.name || tokenEntry?.name || filename,
+        description: parsed.description || '',
+        body: parsed.body,
+        tokens: tokenEntry?.tokens || 0,
+      })
+    );
+  }
+
+  const candidates = prompts
+    .filter((prompt) => prompt.priority > 0)
+    .sort((left, right) => right.priority - left.priority || right.tokens - left.tokens)
+    .slice(0, limit);
+
+  return {
+    promptCount: prompts.length,
+    totalTokens: prompts.reduce((sum, prompt) => sum + prompt.tokens, 0),
+    categoryTotals: categoryTotals(prompts),
+    candidates,
+  };
+}
+
+function categoryTotals(prompts) {
+  const totals = new Map();
+  for (const prompt of prompts) {
+    const current = totals.get(prompt.category) || { count: 0, tokens: 0 };
+    current.count += 1;
+    current.tokens += prompt.tokens;
+    totals.set(prompt.category, current);
+  }
+  return [...totals.entries()]
+    .map(([category, value]) => ({ category, ...value }))
+    .sort((left, right) => right.tokens - left.tokens);
+}
+
+export function renderSlimmingReport(analysis) {
+  const lines = [
+    '# Prompt Slimming Candidates',
+    '',
+    `Prompts analyzed: ${analysis.promptCount}`,
+    `README token total: ${analysis.totalTokens.toLocaleString()} tokens`,
+    '',
+    '## Token Totals By Category',
+    '',
+    '| Category | Prompts | Tokens |',
+    '| --- | ---: | ---: |',
+  ];
+
+  for (const total of analysis.categoryTotals) {
+    lines.push(
+      `| ${total.category} | ${total.count} | ${total.tokens.toLocaleString()} |`
+    );
+  }
+
+  lines.push('', '## Highest Priority Candidates', '');
+
+  for (const [index, prompt] of analysis.candidates.entries()) {
+    lines.push(
+      `${index + 1}. ${prompt.name} (${prompt.tokens.toLocaleString()} tokens, ${prompt.filename})`
+    );
+    lines.push(`   - Category: ${prompt.category}`);
+    lines.push(`   - Why: ${prompt.reasons.join('; ') || 'low structural signal'}`);
+    lines.push(`   - Suggested cut: ${prompt.actions.join('; ')}`);
+  }
+
+  lines.push('');
+  return `${lines.join('\n')}\n`;
+}

--- a/tools/promptSlimmingAnalysis.test.mjs
+++ b/tools/promptSlimmingAnalysis.test.mjs
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+
+import {
+  analyzePrompts,
+  classifyPrompt,
+  parsePromptMarkdown,
+  parseReadmeTokenCounts,
+  promptCategory,
+  renderSlimmingReport,
+} from './promptSlimmingAnalysis.mjs';
+
+test('parseReadmeTokenCounts extracts filenames and token counts', () => {
+  const counts = parseReadmeTokenCounts(`
+- [Data: Big reference](./system-prompts/data-big-reference.md) (**1234** tks) - Reference.
+- [**System Prompt: Main**](./system-prompts/system-prompt-main.md) (**42** tks) - Main.
+`);
+
+  assert.equal(counts.get('data-big-reference.md').tokens, 1234);
+  assert.equal(counts.get('system-prompt-main.md').name, 'System Prompt: Main');
+});
+
+test('parsePromptMarkdown reads generated metadata and body', () => {
+  const parsed = parsePromptMarkdown(`<!--
+name: "Skill: Example"
+description: "A quoted description"
+ccVersion: "2.1.220"
+-->
+Body text.
+`);
+
+  assert.equal(parsed.name, 'Skill: Example');
+  assert.equal(parsed.description, 'A quoted description');
+  assert.equal(parsed.body, 'Body text.\n');
+});
+
+test('promptCategory maps generated prompt prefixes', () => {
+  assert.equal(promptCategory('Data: Claude API reference'), 'data');
+  assert.equal(promptCategory('Tool Description: Bash'), 'tool');
+  assert.equal(promptCategory('System Reminder: Plan mode'), 'reminder');
+  assert.equal(promptCategory('Other prompt'), 'other');
+});
+
+test('classifyPrompt prefers retrieval for large data prompts', () => {
+  const classified = classifyPrompt({
+    filename: 'data-api-reference.md',
+    name: 'Data: API reference',
+    body: 'You must follow this.\nFor example:\n```js\ncall();\n```\n'.repeat(50),
+    tokens: 12_000,
+  });
+
+  assert.equal(classified.category, 'data');
+  assert.ok(classified.priority >= 8);
+  assert.ok(classified.reasons.includes('very large token footprint'));
+  assert.ok(
+    classified.actions.includes(
+      'move reference material behind retrieval or an explicit help/docs command'
+    )
+  );
+});
+
+test('analyzePrompts ranks candidates from prompt files and README counts', () => {
+  const root = mkdtempSync(join(tmpdir(), 'prompt-slimming-'));
+  const promptsDir = join(root, 'system-prompts');
+  mkdirSync(promptsDir);
+
+  try {
+    writeFileSync(
+      join(root, 'README.md'),
+      [
+        '- [Data: Big reference](./system-prompts/data-big-reference.md) (**9000** tks) - Reference.',
+        '- [Tool Description: Bash details](./system-prompts/tool-description-bash-details.md) (**1200** tks) - Tool.',
+      ].join('\n')
+    );
+    writeFileSync(
+      join(promptsDir, 'data-big-reference.md'),
+      `<!--
+name: "Data: Big reference"
+description: "Reference docs"
+ccVersion: "2.1.220"
+-->
+For example, this reference has many details.
+`
+    );
+    writeFileSync(
+      join(promptsDir, 'tool-description-bash-details.md'),
+      `<!--
+name: "Tool Description: Bash details"
+description: "Tool docs"
+ccVersion: "2.1.220"
+-->
+You must validate input. Never hide errors.
+`
+    );
+
+    const analysis = analyzePrompts({
+      promptsDir,
+      readmePath: join(root, 'README.md'),
+      limit: 1,
+    });
+
+    assert.equal(analysis.promptCount, 2);
+    assert.equal(analysis.totalTokens, 10_200);
+    assert.equal(analysis.candidates.length, 1);
+    assert.equal(analysis.candidates[0].name, 'Data: Big reference');
+
+    const report = renderSlimmingReport(analysis);
+    assert.match(report, /Prompt Slimming Candidates/);
+    assert.match(report, /Data: Big reference/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tools/suggestPromptSlimming.mjs
+++ b/tools/suggestPromptSlimming.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import { writeFileSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+import { analyzePrompts, renderSlimmingReport } from './promptSlimmingAnalysis.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT_DIR = join(__dirname, '..');
+
+function parseArgs(args) {
+  const options = {
+    limit: 30,
+    outputPath: null,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--limit') {
+      options.limit = Number.parseInt(args[++index], 10);
+    } else if (arg === '--out') {
+      options.outputPath = resolve(args[++index]);
+    } else if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!Number.isInteger(options.limit) || options.limit <= 0) {
+    throw new Error('--limit must be a positive integer');
+  }
+
+  return options;
+}
+
+function usage() {
+  return [
+    'Usage: node tools/suggestPromptSlimming.mjs [--limit N] [--out path]',
+    '',
+    'Ranks extracted Claude Code prompt files by token footprint and structural',
+    'signals that suggest the content should move from always-on prompt prose',
+    'into tool schemas, runtime state, skills, or retrieval-backed references.',
+    '',
+  ].join('\n');
+}
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write(usage());
+    process.exit(0);
+  }
+
+  const analysis = analyzePrompts({
+    promptsDir: join(ROOT_DIR, 'system-prompts'),
+    readmePath: join(ROOT_DIR, 'README.md'),
+    limit: options.limit,
+  });
+  const report = renderSlimmingReport(analysis);
+
+  if (options.outputPath) {
+    writeFileSync(options.outputPath, report);
+  } else {
+    process.stdout.write(report);
+  }
+} catch (error) {
+  console.error(error.message);
+  console.error('');
+  console.error(usage());
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- add a prompt slimming analyzer for extracted Claude Code prompt files
- generate a current `PROMPT_SLIMMING.md` snapshot ranking high-token prompt candidates
- document the analysis workflow in `README.md`

## Motivation

Recent prompt reductions in Claude Code suggest that large always-on prompt prose can become counterproductive as models improve. This adds a lightweight local analysis tool that identifies prompt weight that may be better moved into retrieval-backed references, lazy-loaded skills, tool schemas, validation, or concise runtime errors.

The extracted prompt markdown files remain unchanged because they are reference output generated from upstream Claude Code releases.

## Testing

- `node --test tools/*.test.mjs`
- `node tools/suggestPromptSlimming.mjs --limit 12`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a prompt analysis tool that identifies and ranks high-token prompt documents for potential slimming.
  * Added configurable command-line options for result limits, output files, help, and error handling.
  * Added a generated report with token totals, category breakdowns, prioritized candidates, and suggested reductions.

* **Documentation**
  * Added usage instructions and guidance for reviewing prompt slimming results in the README.

* **Tests**
  * Added coverage for metadata parsing, categorization, prioritization, analysis, and report generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->